### PR TITLE
Add support for custom Unikraft configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,14 @@ CONFIG_SUFFIX := \
            $(subst $(SPACE),+,$(OCUKEXTLIBS))\
            $(subst $(SPACE),+,$(OCUKCONFIGOPTS))))
 
+SED_CLEAN_CONFIG := sed -e '/Unikraft.*Configuration/d' \
+                        -e '/CONFIG_UK_FULLVERSION/d' \
+                        -e '/CONFIG_HOST_ARCH/d' \
+                        -e '/CONFIG_UK_BASE/d' \
+                        -e '/CONFIG_UK_APP/d'
+
+ifeq ("$(OCUKCUSTOMCFGDIR)","")
+
 CONFIG := dummykernel/$(OCUKPLAT)-$(OCUKARCH)$(CONFIG_SUFFIX).fullconfig
 
 # Build the intermediate configuration file from configuration chunks
@@ -95,12 +103,7 @@ fullconfig: dummykernel/$(OCUKPLAT)-$(OCUKARCH)$(CONFIG_SUFFIX).config \
     | $(BEBLDLIBDIR)/Makefile $(OCUKEXTLIBSDEPS)
 	cp $< $(CONFIG)
 	$(UKMAKE) olddefconfig
-	sed -e '/Unikraft.*Configuration/d' \
-	    -e '/CONFIG_UK_FULLVERSION/d' \
-	    -e '/CONFIG_HOST_ARCH/d' \
-	    -e '/CONFIG_UK_BASE/d' \
-	    -e '/CONFIG_UK_APP/d' \
-	    -i $(CONFIG)
+	$(SED_CLEAN_CONFIG) -i $(CONFIG)
 
 # Rebuild all the full configurations
 .PHONY: fullconfigs
@@ -115,6 +118,20 @@ fullconfigs:
 	    done \
 	  done \
 	done
+
+else # $(OCUKCUSTOMCFGDIR) != ""
+
+CONFIG := custom-$(OCUKPLAT)-$(OCUKARCH)$(CONFIG_SUFFIX).fullconfig
+
+$(CONFIG): \
+  $(OCUKCUSTOMCFGDIR)/$(OCUKPLAT)-$(OCUKARCH)$(CONFIG_SUFFIX).fullconfig
+	cp $< $@
+
+endif # $(OCUKCUSTOMCFGDIR)
+
+.PHONY: cleanconfig
+cleanconfig:
+	$(SED_CLEAN_CONFIG) -i $(CONFIG)
 
 
 # BUILD OF DUMMYKERNEL

--- a/Makefile
+++ b/Makefile
@@ -59,18 +59,8 @@ all: compiler
 # Quote for sh
 SHQUOTE = '$(subst ','\'',$(1))'
 
-# BUILD OF DUMMYKERNEL
-########################
-
-LIBMUSL := _build/libs/musl
-MUSLARCHIVE := $(wildcard $(UNIKRAFTMUSL)/musl-*.tar.gz)
-MUSLARCHIVEPATH := $(BEBLDLIBDIR)/libmusl/$(notdir $(MUSLARCHIVE))
-
-OCUKEXTLIBSDEPS := $(addprefix _build/libs/,$(OCUKEXTLIBS))
-OCUKEXTLIBSARCHIVES :=
-ifneq ("$(findstring musl,$(OCUKEXTLIBS))","")
-OCUKEXTLIBSARCHIVES := $(OCUKEXTLIBSARCHIVES) $(MUSLARCHIVEPATH)
-endif
+# UNIKRAFT CONFIGURATION
+##########################
 
 # The suffix has the form `-liba+libb+libc-optx+opty`
 CONFIG_SUFFIX := \
@@ -80,39 +70,6 @@ CONFIG_SUFFIX := \
            $(subst $(SPACE),+,$(OCUKCONFIGOPTS))))
 
 CONFIG := dummykernel/$(OCUKPLAT)-$(OCUKARCH)$(CONFIG_SUFFIX).fullconfig
-
-UKMAKE := umask 0022 && \
-   $(MAKE) -C $(BEBLDLIBDIR) \
-       CONFIG_UK_BASE="$(UNIKRAFT)/" \
-       O="$$PWD/$(BEBLDLIBDIR)/" \
-       A="$$PWD/dummykernel/" \
-       L="$(subst $(SPACE),:,$(addprefix $$PWD/,$(OCUKEXTLIBSDEPS)))" \
-       N=dummykernel \
-       C="$$PWD/$(CONFIG)"
-
-# Main build rule for the dummy kernel
-$(BACKENDBUILT): $(CONFIG) | $(BEBLDLIBDIR)/Makefile $(LIB)/unikraft \
-    $(OCUKEXTLIBSDEPS) $(OCUKEXTLIBSARCHIVES)
-	+$(UKMAKE) sub_make_exec=1
-	touch $@
-
-_build/libs/musl:
-	@if test -z "$(MUSLARCHIVE)" ; then \
-	    echo "Cannot find lib-musl sources;" \
-	        "set UNIKRAFTMUSL=... in your $(MAKE) call"; \
-	    false; \
-	fi
-	mkdir -p $(dir $@)
-	$(SYMLINK) "$(UNIKRAFTMUSL)" $@
-
-$(MUSLARCHIVEPATH): $(MUSLARCHIVE)
-	@if test -z "$<" ; then \
-	    echo "Cannot find lib-musl sources;" \
-	        "set UNIKRAFTMUSL=... in your $(MAKE) call"; \
-	    false; \
-	fi
-	mkdir -p $(dir $@)
-	cp $< $@
 
 # Build the intermediate configuration file from configuration chunks
 CONFIG_CHUNKS := arch/$(OCUKARCH) plat/$(OCUKPLAT)
@@ -158,6 +115,53 @@ fullconfigs:
 	    done \
 	  done \
 	done
+
+
+# BUILD OF DUMMYKERNEL
+########################
+
+LIBMUSL := _build/libs/musl
+MUSLARCHIVE := $(wildcard $(UNIKRAFTMUSL)/musl-*.tar.gz)
+MUSLARCHIVEPATH := $(BEBLDLIBDIR)/libmusl/$(notdir $(MUSLARCHIVE))
+
+OCUKEXTLIBSDEPS := $(addprefix _build/libs/,$(OCUKEXTLIBS))
+OCUKEXTLIBSARCHIVES :=
+ifneq ("$(findstring musl,$(OCUKEXTLIBS))","")
+OCUKEXTLIBSARCHIVES := $(OCUKEXTLIBSARCHIVES) $(MUSLARCHIVEPATH)
+endif
+
+UKMAKE := umask 0022 && \
+   $(MAKE) -C $(BEBLDLIBDIR) \
+       CONFIG_UK_BASE="$(UNIKRAFT)/" \
+       O="$$PWD/$(BEBLDLIBDIR)/" \
+       A="$$PWD/dummykernel/" \
+       L="$(subst $(SPACE),:,$(addprefix $$PWD/,$(OCUKEXTLIBSDEPS)))" \
+       N=dummykernel \
+       C="$$PWD/$(CONFIG)"
+
+# Main build rule for the dummy kernel
+$(BACKENDBUILT): $(CONFIG) | $(BEBLDLIBDIR)/Makefile $(LIB)/unikraft \
+    $(OCUKEXTLIBSDEPS) $(OCUKEXTLIBSARCHIVES)
+	+$(UKMAKE) sub_make_exec=1
+	touch $@
+
+_build/libs/musl:
+	@if test -z "$(MUSLARCHIVE)" ; then \
+	    echo "Cannot find lib-musl sources;" \
+	        "set UNIKRAFTMUSL=... in your $(MAKE) call"; \
+	    false; \
+	fi
+	mkdir -p $(dir $@)
+	$(SYMLINK) "$(UNIKRAFTMUSL)" $@
+
+$(MUSLARCHIVEPATH): $(MUSLARCHIVE)
+	@if test -z "$<" ; then \
+	    echo "Cannot find lib-musl sources;" \
+	        "set UNIKRAFTMUSL=... in your $(MAKE) call"; \
+	    false; \
+	fi
+	mkdir -p $(dir $@)
+	cp $< $@
 
 $(BEBLDLIBDIR)/Makefile: | $(BEBLDLIBDIR) $(LIB)/unikraft
 	test -e "$(UNIKRAFT)/Makefile"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ both QEMU and Firecracker require some configuration to run a unikernel. The
 OCaml code of those examples are all quite simple, though.
 
 
+## Custom configurations
+
+Unikraft offers a lot of configuration options. The `ocaml-unikraft-option-*`
+packages give an easy way to enable some options but the exponential number of
+combinations make this obviously limited. To expose nevertheless the rich set of
+Unikraft options, you can create a package with custom configurations starting
+from this [template]. The template repository provides more detailed
+instructions on how to proceed.
+
+[template]: https://github.com/mirage/ocaml-unikraft-custom-configs
+
+
 ## Development
 
 It is possible to build this project fully locally, which is really what is used

--- a/gen_opams.ml
+++ b/gen_opams.ml
@@ -278,6 +278,7 @@ depopts: [|}
         options;
       Printf.fprintf out
         {|
+  "ocaml-unikraft-custom-configs"
 ]
 build: [
   [
@@ -290,6 +291,8 @@ build: [
     "OCUKEXTLIBS=musl"
     "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
     "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%%{ocaml-unikraft-custom-configs:share}%%"
+      {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
     "%%{name}%%.install"
   ]

--- a/ocaml-unikraft-backend-firecracker-arm64.opam
+++ b/ocaml-unikraft-backend-firecracker-arm64.opam
@@ -18,6 +18,7 @@ depends: [
 depopts: [
   "ocaml-unikraft-option-debug"
   "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
 ]
 build: [
   [
@@ -30,6 +31,8 @@ build: [
     "OCUKEXTLIBS=musl"
     "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
     "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
     "%{name}%.install"
   ]

--- a/ocaml-unikraft-backend-firecracker-x86_64.opam
+++ b/ocaml-unikraft-backend-firecracker-x86_64.opam
@@ -18,6 +18,7 @@ depends: [
 depopts: [
   "ocaml-unikraft-option-debug"
   "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
 ]
 build: [
   [
@@ -30,6 +31,8 @@ build: [
     "OCUKEXTLIBS=musl"
     "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
     "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
     "%{name}%.install"
   ]

--- a/ocaml-unikraft-backend-qemu-arm64.opam
+++ b/ocaml-unikraft-backend-qemu-arm64.opam
@@ -18,6 +18,7 @@ depends: [
 depopts: [
   "ocaml-unikraft-option-debug"
   "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
 ]
 build: [
   [
@@ -30,6 +31,8 @@ build: [
     "OCUKEXTLIBS=musl"
     "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
     "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
     "%{name}%.install"
   ]

--- a/ocaml-unikraft-backend-qemu-x86_64.opam
+++ b/ocaml-unikraft-backend-qemu-x86_64.opam
@@ -18,6 +18,7 @@ depends: [
 depopts: [
   "ocaml-unikraft-option-debug"
   "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
 ]
 build: [
   [
@@ -30,6 +31,8 @@ build: [
     "OCUKEXTLIBS=musl"
     "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
     "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
     "%{name}%.install"
   ]


### PR DESCRIPTION
This PR adds support for custom Unikraft configurations, that can be installed as a `ocaml-unikraft-custom-configs` package. A [repo](https://github.com/shym/ocaml-unikraft-custom-configs) provides a template to create such a package and suggests how to fine-tune configurations.