### PR TITLE
Build a relocatable cross compiler with OCaml 5.5.*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,10 @@ $(OCAMLBUILT): ocaml/Makefile.config | _build
 	PATH="$$PWD/$(BLDBIN):$$PATH" \
 	  $(MAKE) -C ocaml crossopt \
 	    prefix=$(call SHQUOTE,$(prefix)/lib/$(OCAMLPKG)) \
-	    OLDS="-o yacc/ocamlyacc -o lex/ocamllex"
+	    OLDS="-o yacc/ocamlyacc -o lex/ocamllex" \
+	    $$(case "$$(ocamlc -vnum)" in \
+	         5.5.*) echo LIBDIR=../lib/ocaml ;; \
+	       esac)
 	touch $@
 
 OCAMLFIND_CONF := _build/unikraft_$(OCUKARCH).conf


### PR DESCRIPTION
Work around the issue that the `--with-relative-libdir` configuration option is ignored when building a cross compiler as the library directory is confused between host and target.