### PR TITLE
Support cross-building the OCaml toolchain on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,16 +298,15 @@ ocaml/Makefile.config: $(TOOLCHAIN) | ocaml
 		--with-additional-stublibsdir \
 		--with-relative-libdir \
 		--enable-runtime-search \
-		--enable-runtime-search-target
+		--enable-runtime-search-target \
+		$(OCAMLCONFIGUREEXTRA)
 
 $(OCAMLBUILT): ocaml/Makefile.config | _build
 	PATH="$$PWD/$(BLDBIN):$$PATH" \
 	  $(MAKE) -C ocaml crossopt \
 	    prefix=$(call SHQUOTE,$(prefix)/lib/$(OCAMLPKG)) \
 	    OLDS="-o yacc/ocamlyacc -o lex/ocamllex" \
-	    $$(case "$$(ocamlc -vnum)" in \
-	         5.5.*) echo LIBDIR=../lib/ocaml ;; \
-	       esac)
+	    $$(ocamlc -vnum | grep -qE '^5[.]5[.]' && echo LIBDIR=../lib/ocaml)
 	touch $@
 
 OCAMLFIND_CONF := _build/unikraft_$(OCUKARCH).conf

--- a/gen_opams.ml
+++ b/gen_opams.ml
@@ -117,7 +117,7 @@ tags: "org:mirage"|};
             src checksum);
       if !repository_layout then
         Printf.fprintf out
-          {|available: os = "linux"
+          {|available: os = "linux" | os = "macos"
 x-maintenance-intent: ["(latest)"]
 |})
 
@@ -162,7 +162,7 @@ url {
     "sha256=f1e97df806acbd1a0a31ce4ca385e44ab65a1732c92199bd9ef50de4ceca7c76"
 }
 available:
-  os = "linux" &
+  (os = "linux" | os = "macos") &
   (arch = "arm64" | arch = "x86_64" | arch = "s390x" | arch = "riscv64" |
    arch = "ppc64")
 x-maintenance-intent: ["(latest)"]
@@ -317,11 +317,12 @@ build: [
     "OCUKCUSTOMCFGDIR=%%{ocaml-unikraft-custom-configs:share}%%"
       {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
+    "CROSS_COMPILE=%s-linux-gnu-" {os = "macos"}
     "%%{name}%%.install"
   ]
 ]
 |}
-        short_name arch;
+        short_name arch (prefix_arch arch);
       if !repository_layout then
         Printf.fprintf out
           {|x-ci-accept-failures: [

--- a/ocaml-unikraft-backend-firecracker-arm64.opam
+++ b/ocaml-unikraft-backend-firecracker-arm64.opam
@@ -34,6 +34,7 @@ build: [
     "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
       {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
+    "CROSS_COMPILE=aarch64-linux-gnu-" {os = "macos"}
     "%{name}%.install"
   ]
 ]

--- a/ocaml-unikraft-backend-firecracker-x86_64.opam
+++ b/ocaml-unikraft-backend-firecracker-x86_64.opam
@@ -34,6 +34,7 @@ build: [
     "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
       {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
+    "CROSS_COMPILE=x86_64-linux-gnu-" {os = "macos"}
     "%{name}%.install"
   ]
 ]

--- a/ocaml-unikraft-backend-qemu-arm64.opam
+++ b/ocaml-unikraft-backend-qemu-arm64.opam
@@ -34,6 +34,7 @@ build: [
     "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
       {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
+    "CROSS_COMPILE=aarch64-linux-gnu-" {os = "macos"}
     "%{name}%.install"
   ]
 ]

--- a/ocaml-unikraft-backend-qemu-x86_64.opam
+++ b/ocaml-unikraft-backend-qemu-x86_64.opam
@@ -34,6 +34,7 @@ build: [
     "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
       {ocaml-unikraft-custom-configs:installed}
     "UK_CFLAGS=-std=gnu11"
+    "CROSS_COMPILE=x86_64-linux-gnu-" {os = "macos"}
     "%{name}%.install"
   ]
 ]

--- a/patches/5.3.0/0008-Add-a-Makefile.cross-with-rules-to-build-a-cross-com.patch
+++ b/patches/5.3.0/0008-Add-a-Makefile.cross-with-rules-to-build-a-cross-com.patch
@@ -89,10 +89,10 @@ index 0000000000..c30d2e2b4f
 +	$(MAKE) -C otherlibs all $(CROSS_OVERRIDES)
 +	$(MAKE) runtimeopt
 +	$(MAKE) ocamlc.opt ocamlopt.opt $(TOOLS_NATIVE_TARGETS) \
-+	  $(CROSS_COMPILER_OVERRIDES) "$(HOST_ZSTD_LIBS)"
++	  $(CROSS_COMPILER_OVERRIDES) OC_NATIVE_COMPFLAGS= "$(HOST_ZSTD_LIBS)"
 +	$(MAKE) libraryopt $(CROSS_OVERRIDES)
 +	$(MAKE) otherlibrariesopt ocamltoolsopt $(CROSS_OVERRIDES)
-+	$(MAKE) tools-allopt.opt $(CROSS_COMPILER_OVERRIDES)
++	$(MAKE) tools-allopt.opt $(CROSS_COMPILER_OVERRIDES) OC_NATIVE_COMPFLAGS=
 +	# We now build the compiler libs again, but for target this time
 +	rm -f $(ocamlcommon_NCOBJS) $(ocamlmiddleend_NCOBJS) \
 +	  $(ocamlbytecomp_NCOBJS) $(ocamloptcomp_NCOBJS) \

--- a/patches/5.4.0/0003-Makefile.cross-keep-function-sections-off-the-host-.patch
+++ b/patches/5.4.0/0003-Makefile.cross-keep-function-sections-off-the-host-.patch
@@ -1,0 +1,42 @@
+From 3bf151678f524f65a96d0e2173735e37243b5082 Mon Sep 17 00:00:00 2001
+From: Thomas Gazagnaire <thomas@gazagnaire.org>
+Date: Wed, 8 Jul 2026 23:43:23 -0700
+Subject: [PATCH 3/3] Makefile.cross: keep -function-sections off the host .opt
+ tools
+
+crossopt builds ocamlc.opt/ocamlopt.opt and the *.opt tools with the host
+ocamlopt, but injects the target's OC_NATIVE_COMPFLAGS (which includes
+-function-sections when the target supports it) into every native compile.
+When the target enables function sections but the host does not -- an ELF
+cross target built on a macOS host, whose ocamlopt is Mach-O and rejects
+-function-sections -- crossopt fails building the host tools.
+
+Neutralise OC_NATIVE_COMPFLAGS for those host-only .opt builds; the target
+library/otherlibs phases keep it, so target code is still emitted with
+function sections (and can be garbage-collected by the linker).
+---
+ Makefile.cross | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.cross b/Makefile.cross
+index b0a21c3d7c..af7e0d5b21 100644
+--- a/Makefile.cross
++++ b/Makefile.cross
+@@ -76,11 +76,15 @@ endif
+ 	$(MAKE) dynlink-all $(CROSS_OVERRIDES) $(OLDS)
+ 	$(MAKE) -C otherlibs all $(CROSS_OVERRIDES) $(OLDS)
+ 	$(MAKE) runtimeopt $(OLDS)
++# Host binaries: drop OC_NATIVE_COMPFLAGS (e.g. -function-sections, which a
++# Mach-O host ocamlopt rejects); the target phases below keep it.
+ 	$(MAKE) ocamlc.opt ocamlopt.opt $(TOOLS_NATIVE_TARGETS) \
+-	  $(CROSS_COMPILER_OVERRIDES) "$(HOST_ZSTD_LIBS)" $(OLDS)
++	  $(CROSS_COMPILER_OVERRIDES) OC_NATIVE_COMPFLAGS= \
++	  "$(HOST_ZSTD_LIBS)" $(OLDS)
+ 	$(MAKE) libraryopt $(CROSS_OVERRIDES) $(OLDS)
+ 	$(MAKE) otherlibrariesopt ocamltoolsopt $(CROSS_OVERRIDES) $(OLDS)
+-	$(MAKE) tools-allopt.opt $(CROSS_COMPILER_OVERRIDES) $(OLDS)
++	$(MAKE) tools-allopt.opt $(CROSS_COMPILER_OVERRIDES) OC_NATIVE_COMPFLAGS= \
++	  $(OLDS)
+ 	# We now build the compiler libs again, but for target this time
+ 	rm -f $(ocamlcommon_NCOBJS) $(ocamlmiddleend_NCOBJS) \
+ 	  $(ocamlbytecomp_NCOBJS) $(ocamloptcomp_NCOBJS) \

--- a/patches/5.5.0/0001-Makefile.cross-keep-function-sections-off-the-host-.patch
+++ b/patches/5.5.0/0001-Makefile.cross-keep-function-sections-off-the-host-.patch
@@ -1,0 +1,42 @@
+From e4dbf608b08d03e7af71e123ddddf9ad576e4092 Mon Sep 17 00:00:00 2001
+From: Thomas Gazagnaire <thomas@gazagnaire.org>
+Date: Wed, 8 Jul 2026 23:51:53 -0700
+Subject: [PATCH 1/1] Makefile.cross: keep -function-sections off the host .opt
+ tools
+
+crossopt builds ocamlc.opt/ocamlopt.opt and the *.opt tools with the host
+ocamlopt, but injects the target's OC_NATIVE_COMPFLAGS (which includes
+-function-sections when the target supports it) into every native compile.
+When the target enables function sections but the host does not -- an ELF
+cross target built on a macOS host, whose ocamlopt is Mach-O and rejects
+-function-sections -- crossopt fails building the host tools.
+
+Neutralise OC_NATIVE_COMPFLAGS for those host-only .opt builds; the target
+library/otherlibs phases keep it, so target code is still emitted with
+function sections (and can be garbage-collected by the linker).
+---
+ Makefile.cross | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.cross b/Makefile.cross
+index cf069212ea..a33ad8f28d 100644
+--- a/Makefile.cross
++++ b/Makefile.cross
+@@ -89,11 +89,15 @@ endif
+ 	$(MAKE) dynlink-all $(CROSS_OVERRIDES) $(OLDS)
+ 	$(MAKE) -C otherlibs all $(CROSS_OVERRIDES) $(OLDS)
+ 	$(MAKE) runtimeopt $(OLDS)
++# Host binaries: drop OC_NATIVE_COMPFLAGS (e.g. -function-sections, which a
++# Mach-O host ocamlopt rejects); the target phases below keep it.
+ 	$(MAKE) ocamlc.opt ocamlopt.opt $(TOOLS_NATIVE_TARGETS) \
+-	  $(CROSS_COMPILER_OVERRIDES) "$(HOST_ZSTD_LIBS)" $(OLDS)
++	  $(CROSS_COMPILER_OVERRIDES) OC_NATIVE_COMPFLAGS= \
++	  "$(HOST_ZSTD_LIBS)" $(OLDS)
+ 	$(MAKE) libraryopt $(CROSS_OVERRIDES) $(OLDS)
+ 	$(MAKE) otherlibrariesopt ocamltoolsopt $(CROSS_OVERRIDES) $(OLDS)
+-	$(MAKE) tools-allopt.opt $(CROSS_COMPILER_OVERRIDES) $(OLDS)
++	$(MAKE) tools-allopt.opt $(CROSS_COMPILER_OVERRIDES) OC_NATIVE_COMPFLAGS= \
++	  $(OLDS)
+ 	# We now build the compiler libs again, but for target this time
+ 	rm -f $(ocamlcommon_NCOBJS) $(ocamlmiddleend_NCOBJS) \
+ 	  $(ocamlbytecomp_NCOBJS) $(ocamloptcomp_NCOBJS) \


### PR DESCRIPTION
I'd like to cross-build Unikraft OCaml unikernels on an Apple Silicon Mac.

On a macOS host, targeting `aarch64-linux` is a cross build the arch check misses: host and target arch are both aarch64, only the OS differs, so the build falls back to the host compiler unless `CROSS_COMPILE` is set. This sets it for `{os = "macos"}` to the same `<arch>-linux-gnu-` prefix Linux auto-selects. The `messense/macos-cross-toolchains` Homebrew tap provides that full toolchain (gcc and binutils under `aarch64-linux-gnu-*`), so the existing `conf-<arch>-linux-gnu-gcc` dependency resolves on macOS too, with no divergent triple or gating.

It also passes `--disable-function-sections` to the OCaml configure on macOS, since crossopt's ocamlopt is built without function-sections support, and marks the packages available on macOS.

The same `--disable-function-sections` finding drives the macOS support in the sibling ocaml-solo5 backend (mirage/ocaml-solo5#171).
