### PR TITLE
Support OCaml 5.4.1

### DIFF
--- a/gen_opams.ml
+++ b/gen_opams.ml
@@ -355,7 +355,7 @@ description:
 authors: "Samuel Hym"
 license: ["MIT" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"]
 depends: [
-  "ocaml" {>= "5.3.0" & <= "5.4.0"}
+  "ocaml" {>= "5.3.0" & <= "5.4.1"}
   "ocaml-unikraft-toolchain-%s"
   "ocamlfind"
   "ocaml-src" {build}

--- a/ocaml-unikraft-arm64.opam
+++ b/ocaml-unikraft-arm64.opam
@@ -13,7 +13,7 @@ description:
 authors: "Samuel Hym"
 license: ["MIT" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"]
 depends: [
-  "ocaml" {>= "5.3.0" & <= "5.4.0"}
+  "ocaml" {>= "5.3.0" & <= "5.4.1"}
   "ocaml-unikraft-toolchain-arm64"
   "ocamlfind"
   "ocaml-src" {build}

--- a/ocaml-unikraft-x86_64.opam
+++ b/ocaml-unikraft-x86_64.opam
@@ -13,7 +13,7 @@ description:
 authors: "Samuel Hym"
 license: ["MIT" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"]
 depends: [
-  "ocaml" {>= "5.3.0" & <= "5.4.0"}
+  "ocaml" {>= "5.3.0" & <= "5.4.1"}
   "ocaml-unikraft-toolchain-x86_64"
   "ocamlfind"
   "ocaml-src" {build}

--- a/patches/5.4.1/0001-Accept-native-freestanding-targets-at-configure-time.patch
+++ b/patches/5.4.1/0001-Accept-native-freestanding-targets-at-configure-time.patch
@@ -1,0 +1,88 @@
+From beed323b4736e36baa633fa75dd5799d00ad6d8a Mon Sep 17 00:00:00 2001
+From: Samuel Hym <samuel@tarides.com>
+Date: Mon, 26 Feb 2024 19:35:26 +0100
+Subject: [PATCH 1/2] Accept native freestanding targets at configure time
+
+Accept `*-none` and `*-elf*` triplets for all the architectures with a
+native backend to describe the corresponding freestanding target; `none`
+and `elf*` are the most commonly-used last components in triplets for
+freestanding targets
+Set `system` to `none` and `os_type` to `None` in such cases
+---
+ configure    | Bin 737974 -> 738675 bytes
+ configure.ac |  18 ++++++++++++++++--
+ 2 files changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 8bb7306cb1..4c54453646 100755
+--- a/configure
++++ b/configure
+@@ -15816,6 +15816,8 @@ esac
+  ;; #(
+   gcc-*,powerpc-*-linux*) :
+     oc_ldflags="-mbss-plt" ;; #(
++  *,*-*-none|*,*-*-elf*) :
++    ostype="None" ;; #(
+   *) :
+      ;;
+ esac
+@@ -18612,7 +18614,19 @@ fi ;; #(
+   riscv64-*-linux*) :
+     has_native_backend=yes; arch=riscv; model=riscv64; system=linux ;; #(
+   x86_64-*-gnu*) :
+-    has_native_backend=yes; arch=amd64; system=gnu
++    has_native_backend=yes; arch=amd64; system=gnu ;; #(
++  aarch64-*-none|arm64-*-none|aarch64-*-elf*|arm64-*-elf*) :
++    has_native_backend=yes; arch=arm64; system=none ;; #(
++  powerpc64le*-*-none|powerpc64le*-*-elf*) :
++    has_native_backend=yes; arch=power; model=ppc64le; system=none ;; #(
++  powerpc64*-*-none|powerpc64*-*-elf*) :
++    has_native_backend=yes; arch=power; model=ppc64; system=none ;; #(
++  riscv64-*-none|riscv64-*-elf*) :
++    has_native_backend=yes; arch=riscv; model=riscv64; system=none ;; #(
++  s390x*-*-none|s390x*-*-elf*) :
++    has_native_backend=yes; arch=s390x; model=z10; system=none ;; #(
++  x86_64-*-none|x86_64-*-elf*) :
++    has_native_backend=yes; arch=amd64; system=none
+  ;; #(
+   *) :
+      ;;
+diff --git a/configure.ac b/configure.ac
+index 0535f404b0..0335bdf184 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1175,7 +1175,9 @@ AS_CASE([$ocaml_cc_vendor,$target],
+     [oc_ldflags='-brtl -bexpfull'
+     AC_DEFINE([HAS_ARCH_CODE32], [1])],
+   [gcc-*,powerpc-*-linux*],
+-    [oc_ldflags="-mbss-plt"])
++    [oc_ldflags="-mbss-plt"],
++  [*,*-*-none|*,*-*-elf*],
++    [ostype="None"])
+ 
+ # How to build sak
+ 
+@@ -1609,7 +1611,19 @@ AS_CASE([$target],
+   [riscv64-*-linux*],
+     [has_native_backend=yes; arch=riscv; model=riscv64; system=linux],
+   [x86_64-*-gnu*],
+-    [has_native_backend=yes; arch=amd64; system=gnu]
++    [has_native_backend=yes; arch=amd64; system=gnu],
++  [aarch64-*-none|arm64-*-none|aarch64-*-elf*|arm64-*-elf*],
++    [has_native_backend=yes; arch=arm64; system=none],
++  [powerpc64le*-*-none|powerpc64le*-*-elf*],
++    [has_native_backend=yes; arch=power; model=ppc64le; system=none],
++  [powerpc64*-*-none|powerpc64*-*-elf*],
++    [has_native_backend=yes; arch=power; model=ppc64; system=none],
++  [riscv64-*-none|riscv64-*-elf*],
++    [has_native_backend=yes; arch=riscv; model=riscv64; system=none],
++  [s390x*-*-none|s390x*-*-elf*],
++    [has_native_backend=yes; arch=s390x; model=z10; system=none],
++  [x86_64-*-none|x86_64-*-elf*],
++    [has_native_backend=yes; arch=amd64; system=none]
+ )
+ 
+ AS_CASE([$arch],
+-- 
+2.51.0
+

--- a/patches/5.4.1/0002-Allow-ocaml-in-a-triplet-target-to-build-freestandin.patch
+++ b/patches/5.4.1/0002-Allow-ocaml-in-a-triplet-target-to-build-freestandin.patch
@@ -1,0 +1,81 @@
+From 9e347c544bfa1dfe940f1961d1548d6c16eb4e09 Mon Sep 17 00:00:00 2001
+From: Samuel Hym <samuel@tarides.com>
+Date: Mon, 26 Feb 2024 11:51:11 +0100
+Subject: [PATCH 2/2] Allow `ocaml` in a triplet target to build freestanding
+ cross compilers
+
+Allow `ocaml` to be used as the last component of the target triplet in
+case we are using a custom toolchain for a freestanding target. The
+target triplet is then temporarily rewritten to "<arch>-none" to compute
+the canonical target.
+
+This allows to use a `*-*-ocaml-` prefixes (ie `x86_64-solo5-ocaml-`) to
+create cross-compiler toolchains dedicated to specific freestanding
+targets
+---
+ configure    | Bin 738675 -> 739161 bytes
+ configure.ac |  13 +++++++++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/configure b/configure
+index 4c54453646..a243ae55cb 100755
+--- a/configure
++++ b/configure
+@@ -3690,6 +3690,21 @@ IFS=$ac_save_IFS
+ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+ 
+ 
++# Allow "ocaml" to be used as the last component of the target triplet in case
++# we are using a custom toolchain for a freestanding target. To do so, the
++# target triplet is temporarily rewritten to "<arch>-none" to compute the
++# canonical target
++save_target_alias="$target_alias"
++case $target_alias in #(
++  *-*-ocaml) :
++    ac_save_IFS=$IFS
++    IFS='-'
++    set x $target_alias
++    target_alias="$2-none"
++    IFS=$ac_save_IFS ;; #(
++  *) :
++     ;;
++esac
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking target system type" >&5
+ printf %s "checking target system type... " >&6; }
+ if test ${ac_cv_target+y}
+@@ -3730,6 +3745,7 @@ test -n "$target_alias" &&
+   test "$program_prefix$program_suffix$program_transform_name" = \
+     NONENONEs,x,x, &&
+   program_prefix=${target_alias}-
++target_alias="$save_target_alias"
+ 
+ # Override cross_compiling and ac_tool_prefix variables since the C toolchain is
+ # used to generate target code when building a cross compiler
+diff --git a/configure.ac b/configure.ac
+index 0335bdf184..856384d8ba 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -302,7 +302,20 @@ AC_CONFIG_COMMANDS_PRE(OCAML_QUOTED_STRING_ID)
+ 
+ AC_CANONICAL_BUILD
+ AC_CANONICAL_HOST
++# Allow "ocaml" to be used as the last component of the target triplet in case
++# we are using a custom toolchain for a freestanding target. To do so, the
++# target triplet is temporarily rewritten to "<arch>-none" to compute the
++# canonical target
++save_target_alias="$target_alias"
++AS_CASE([$target_alias],
++  [*-*-ocaml],
++    [ac_save_IFS=$IFS
++    IFS='-'
++    set x $target_alias
++    target_alias="$2-none"
++    IFS=$ac_save_IFS])
+ AC_CANONICAL_TARGET
++target_alias="$save_target_alias"
+ 
+ # Override cross_compiling and ac_tool_prefix variables since the C toolchain is
+ # used to generate target code when building a cross compiler
+-- 
+2.51.0
+


### PR DESCRIPTION
Widen the compiler constraint to `<= "5.4.1"` and add `patches/5.4.1`; the 5.4.0 freestanding patches apply to 5.4.1 verbatim, so they are copied as-is. The opam files are regenerated from `gen_opams.ml`.

Independent of the macOS cross-build (#14).
