### PR TITLE
Add a remove: field to the unikraft and unikraft-musl packages

### DIFF
--- a/gen_opams.ml
+++ b/gen_opams.ml
@@ -154,6 +154,7 @@ install: [
   ["rm" "-rf" ".github" ".gitignore"]
   ["cp" "-r" "." "%%{_:lib}%%"]
 ]
+remove: [ ["rm" "-rf" "%%{_:lib}%%"] ]
 dev-repo: "git+https://github.com/unikraft/unikraft.git"
 url {
   src:
@@ -196,6 +197,7 @@ install: [
   ["rm" "-rf" ".github"]
   ["cp" "-r" "." "%%{_:lib}%%"]
 ]
+remove: [ ["rm" "-rf" "%%{_:lib}%%"] ]
 dev-repo: "git+https://github.com/unikraft/lib-musl.git"
 url {
   src:


### PR DESCRIPTION
The `unikraft` and `unikraft-musl` packages install with `cp -r . %{_:lib}%`, copying the whole source tree into the package's lib directory with no per-file `.install` manifest. Without a `remove:` field, opam cannot account for those files on uninstall (the opam file it copied in reads as modified), leaves the directory behind, and the next install's `cp` collides with the leftovers, breaking reinstall.

This adds `remove: [ ["rm" "-rf" "%{_:lib}%"] ]` to both templates in `gen_opams.ml`: a whole-tree `cp` wants a whole-tree `rm`. The checked-in `ocaml-unikraft-*.opam` files are unaffected (these two packages are only generated in the repository layout).
