### PR TITLE
examples: pass the backend link flag as two tokens

### DIFF
--- a/examples/all/dune
+++ b/examples/all/dune
@@ -34,7 +34,7 @@
  (action
   (write-file
    "flags"
-   "(-cclib \"-z unikraft-backend=%{env:UNIKRAFTBACKEND=qemu}\")")))
+   "(-cclib -z -cclib unikraft-backend=%{env:UNIKRAFTBACKEND=qemu})")))
 
 (rule
  (enabled_if

--- a/examples/simple/dune
+++ b/examples/simple/dune
@@ -1,6 +1,6 @@
 (executable
  (name hello)
- (flags :standard -cclib "-z unikraft-backend=qemu")
+ (flags :standard -cclib -z -cclib unikraft-backend=qemu)
  (foreign_stubs
   (language c)
   (flags :standard -z unikraft-backend=qemu)


### PR DESCRIPTION
The examples select the Unikraft backend with `-cclib "-z unikraft-backend=qemu"`. `ocamlopt` forwards that to the toolchain wrapper as a single argument, but the wrapper only intercepts a bare `-z` token followed by `unikraft-backend=...`. So the single-argument form is never intercepted: the backend stays unset and the wrapper falls back to its built-in default. An example asking for a non-default backend (e.g. `UNIKRAFTBACKEND=firecracker` in `examples/all`) then silently builds the default one.

This switches both examples to the two-token `-cclib -z -cclib unikraft-backend=...` form, which the wrapper intercepts, and which is the same shape the ocamlfind rules already emit for solo5. The C-stub `(flags ...)` lists were already two tokens and are unchanged.
